### PR TITLE
fix: variable needs quotes

### DIFF
--- a/script/scantoocr-0.2.4-1.sh
+++ b/script/scantoocr-0.2.4-1.sh
@@ -31,4 +31,4 @@ fi
 gm convert /scans/$date-page*.pnm /scans/$date.pdf
 rm /scans/$date-page*.pnm
 
-/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh $SSH_USER $SSH_PASSWORD $SSH_HOST $SSH_PATH $date.pdf
+/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}.pdf"


### PR DESCRIPTION
This commit fixes an issue where variables were not quoted, which would make it so that the user variable in the trigger_inotify.sh script would have the incorrect value.

Before this fix:
```
test_user="test user"; ./trigger_inotify.sh $test_user
user: test
```

After this fix:
```
test_user="test user"; ./trigger_inotify.sh "${test_user}"
user: test user
```