### PR TITLE
fix: setup symlinks for scripts so brscan will find them

### DIFF
--- a/script/scantoemail.sh
+++ b/script/scantoemail.sh
@@ -1,0 +1,1 @@
+scantoemail-0.2.4-1.sh

--- a/script/scantofile.sh
+++ b/script/scantofile.sh
@@ -1,0 +1,1 @@
+scantofile-0.2.4-1.sh

--- a/script/scantoimage.sh
+++ b/script/scantoimage.sh
@@ -1,0 +1,1 @@
+scantoimage-0.2.4-1.sh

--- a/script/scantoocr.sh
+++ b/script/scantoocr.sh
@@ -1,0 +1,1 @@
+scantoocr-0.2.4-1.sh


### PR DESCRIPTION
Add symlinks for the scripts that the brother config points to by default.  Without this change the docker container by default won't find the correct scripts when you hit the scan buttons on the brother scanner.

Feel free to reject this PR if you don't want the default setup to be able to run these scripts.