### PR TITLE
Only trigger inotify if env vars are populated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,10 +21,10 @@ ENV IPADDRESS="192.168.1.123"
 ENV USERNAME="NAS"
 
 #only set these variables, if inotify needs to be triggered (e.g., for CloudStation):
-ENV SSH_USER="admin"
-ENV SSH_PASSWORD="admin"
-ENV SSH_HOST="localhost"
-ENV SSH_PATH="/path/to/scans/folder/"
+ENV SSH_USER=""
+ENV SSH_PASSWORD=""
+ENV SSH_HOST=""
+ENV SSH_PATH=""
 
 #only set these variables, if you need FTP upload:
 ENV FTP_USER="scanner"

--- a/script/trigger_inotify.sh
+++ b/script/trigger_inotify.sh
@@ -6,7 +6,6 @@ file=$5
 
 if [ -z "${user}" ] || [ -z "${password}" ] || [ -z "${address}" ] || [ -z "${filepath}" ]; then
   echo "SSH environment variables not set, skipping inotify trigger."
-  exit 1
 fi
 
 if sshpass -p "$password" ssh -o StrictHostKeyChecking=no $user@$address "sed \"\" -i $filepath/$file"; then

--- a/script/trigger_inotify.sh
+++ b/script/trigger_inotify.sh
@@ -3,4 +3,15 @@ password=$2
 address=$3
 filepath=$4
 file=$5
-sshpass -p "$password" ssh -o StrictHostKeyChecking=no $user@$address "sed \"\" -i $filepath/$file"
+
+if [ -z "${user}" ] || [ -z "${password}" ] || [ -z "${address}" ] || [ -z "${filepath}" ]; then
+  echo "SSH environment variables not set, skipping inotify trigger."
+  exit 1
+fi
+
+if sshpass -p "$password" ssh -o StrictHostKeyChecking=no $user@$address "sed \"\" -i $filepath/$file"; then
+  echo "trigger inotify successful"
+else
+  echo "trigger inotify failed"
+  exit 1
+fi

--- a/script/trigger_inotify.sh
+++ b/script/trigger_inotify.sh
@@ -6,11 +6,12 @@ file=$5
 
 if [ -z "${user}" ] || [ -z "${password}" ] || [ -z "${address}" ] || [ -z "${filepath}" ]; then
   echo "SSH environment variables not set, skipping inotify trigger."
+else
+  if sshpass -p "$password" ssh -o StrictHostKeyChecking=no $user@$address "sed \"\" -i $filepath/$file"; then
+    echo "trigger inotify successful"
+  else
+    echo "trigger inotify failed"
+    exit 1
+  fi
 fi
 
-if sshpass -p "$password" ssh -o StrictHostKeyChecking=no $user@$address "sed \"\" -i $filepath/$file"; then
-  echo "trigger inotify successful"
-else
-  echo "trigger inotify failed"
-  exit 1
-fi


### PR DESCRIPTION
This PR updates the trigger_inotify.sh script so that it only runs if the proper env vars are provided.  Now if someone runs the container but doesn't fill in the `SSH_*` env vars the scripts will run fine, and instead just echo that they are skipping the inotify section.