### PR TITLE
feat: add option to use JPEG compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ You can configure the tool via environment variables:
 | RENAME_GUI_SCANTOEMAIL="Scan rear pages" | optional | renames GUI button "Scan to email" to "Scan rear pages" |
 | RENAME_GUI_SCANTOIMAGE="Scan photo" | optional | renames GUI button "Scan to image" to "Scan photo" |
 | RENAME_GUI_SCANTOOCR="Scan High-Res" | optional | renames GUI button "Scan to OCR" to "Scan High-Res" |
+| USE_JPEG_COMPRESSION | optional | use JPEG compression when creating PDFs |
 
 ### FTPS upload
 In addition to the storage in the mounted volume, you can use FTPS (Secure FTP) Upload.

--- a/script/scanRear.sh
+++ b/script/scanRear.sh
@@ -10,6 +10,13 @@ if [[ $RESOLUTION ]]; then
 else
   resolution=300
 fi
+
+if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
+    compression_flag="-compress JPEG -quality 80"
+else
+    compression_flag=""
+fi
+
 device=$1
 cd /scans
 date=$(ls -rd */ | grep $(date +"%Y-%m-%d") | head -1)
@@ -66,7 +73,7 @@ fi
 	
 	(
 		echo "converting to PDF for $date..."
-		gm convert -page A4+0+0 *.pnm /scans/$date.pdf	
+		gm convert -page A4+0+0 $compression_flag *.pnm /scans/$date.pdf	
 		/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" $date.pdf
 		
 		echo "cleaning up for $date..."

--- a/script/scantofile-0.2.4-1.sh
+++ b/script/scantofile-0.2.4-1.sh
@@ -11,6 +11,13 @@ if [[ $RESOLUTION ]]; then
 else
   resolution=300
 fi
+
+if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
+    compression_flag="-compress JPEG -quality 80"
+else
+    compression_flag=""
+fi
+
 device=$1
 date=$(date +%Y-%m-%d-%H-%M-%S)
 
@@ -49,7 +56,7 @@ fi
 	
 	(
 		echo "converting to PDF for $date..."
-		gm convert -page A4+0+0 $filename_base*.pnm /scans/$date.pdf
+		gm convert -page A4+0+0 $compression_flag $filename_base*.pnm /scans/$date.pdf
 		/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" $date.pdf
 	
 		echo "cleaning up for $date..."


### PR DESCRIPTION
With the default setup, scanned pages take multiple megabytes. The newly added USE_JPEG_COMPRESSION environment variable enables JEPG compression (quality factor 80), significantly reducing file sizes.

see https://codeyarns.com/tech/2010-04-12-graphicsmagick-compression-methods.html