### PR TITLE
Fix some shellcheck warnings

### DIFF
--- a/script/scanRear.sh
+++ b/script/scanRear.sh
@@ -5,96 +5,92 @@
 #override environment, as brscan is screwing it up:
 export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
 
-if [[ $RESOLUTION ]]; then
-  resolution=$RESOLUTION
-else
-  resolution=300
-fi
+resolution="${RESOLUTION:-300}"
 
+gm_opts=(-page A4+0+0)
 if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
-    compression_flag="-compress JPEG -quality 80"
-else
-    compression_flag=""
+  gm_opts+=(-compress JPEG -quality 80)
 fi
 
-device=$1
-cd /scans
-date=$(ls -rd */ | grep $(date +"%Y-%m-%d") | head -1)
+# device=$1
+mkdir -p /tmp
+cd /tmp || exit
+date=$(ls -rd */ | grep "$(date +"%Y-%m-%d")" | head -1)
 date=${date%/}
-filename_base=/scans/$date/$date"-back-page"
-output_file=$filename_base"%04d.pnm"
+filename_base="/tmp/$date/${date}-back-page"
+output_file="${filename_base}%04d.pnm"
 
-cd /scans/$date
+cd "/tmp/${date}" || exit
 
-kill -9 `cat scan_pid`
+kill -9 "$(cat scan_pid)"
 rm scan_pid
 
 #sthg is wrong with device name, probably escaping, use default printer:
 #scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --device-name=$device --resolution=$resolution --batch=$output_file"
 scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --resolution=$resolution --batch=$output_file"
 
-if [ "`which usleep  2>/dev/null `" != '' ];then
-    usleep 100000
+if [ "$(which usleep 2>/dev/null)" != '' ]; then
+  usleep 100000
 else
-    sleep  0.1
+  sleep 0.1
 fi
-$($scan_cmd)
-if [ ! -s $filename_base"0001.pnm" ];then
-  if [ "`which usleep  2>/dev/null `" != '' ];then
+eval "$scan_cmd"
+if [ ! -s "${filename_base}0001.pnm" ]; then
+  if [ "$(which usleep 2>/dev/null)" != '' ]; then
     usleep 1000000
   else
-    sleep  1
+    sleep 1
   fi
-  $($scan_cmd)
+  eval "$scan_cmd"
 fi
 
 (
-	#rename pages:
-	numberOfPages=$(find . -maxdepth 1  -name "*front-page*" | wc -l)
-	echo "number of pages scanned: "$numberOfPages
-	
-	cnt=0
-	for filename in *front*.pnm; do
-	        cnt=$((cnt+1))
-	        cntFormatted=$(printf "%03d" $cnt)
-			if [[ $filename = *"front"* ]]; then
-	                $(mv $filename index$cntFormatted-1-$filename)
-	        fi
-	done
-	cnt=0
-	for filename in *back*.pnm; do
-	        cnt=$((cnt+1))
-	        if [[ $filename = *"back"* ]]; then
-	                rearIndex=$((numberOfPages-cnt+1))
-	                rearIndexFormatted=$(printf "%03d" $rearIndex)
-	                $(mv $filename index$rearIndexFormatted-2-$filename)
-	        fi
-	done
-	
-	(
-		echo "converting to PDF for $date..."
-		gm convert -page A4+0+0 $compression_flag *.pnm /scans/$date.pdf	
-		/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" $date.pdf
-		
-		echo "cleaning up for $date..."
-		cd /scans
-		rm -rf $date
-		
-		if [ -z "${OCR_SERVER}" ] || [ -z "${OCR_PORT}" ] || [ -z "${OCR_PATH}" ]; then
-			echo "OCR environment variables not set, skipping OCR."
-		else
-			echo "starting OCR for $date..."
-			(
-				curl -F "userfile=@/scans/$date.pdf" -H "Expect:" -o /scans/$date-ocr.pdf ${OCR_SERVER}:${OCR_PORT}/${OCR_PATH} 
-				/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" $date-ocr.pdf
+  #rename pages:
+  numberOfPages=$(find . -maxdepth 1 -name "*front-page*" | wc -l)
+  echo "number of pages scanned: $numberOfPages"
 
-				/opt/brother/scanner/brscan-skey/script/sendtoftps.sh \
-				  "${FTP_USER}" \
-				  "${FTP_PASSWORD}" \
-				  "${FTP_HOST}" \
-				  "${FTP_PATH}" \
-				  "${date}.pdf"
-			) &
-		fi
-	) &
+  cnt=0
+  for filename in *front*.pnm; do
+    cnt=$((cnt + 1))
+    cntFormatted=$(printf "%03d" $cnt)
+    if [[ $filename = *"front"* ]]; then
+      mv "$filename" "index${cntFormatted}-1-${filename}"
+    fi
+  done
+  cnt=0
+  for filename in *back*.pnm; do
+    cnt=$((cnt + 1))
+    if [[ $filename = *"back"* ]]; then
+      rearIndex=$((numberOfPages - cnt + 1))
+      rearIndexFormatted=$(printf "%03d" $rearIndex)
+      mv "$filename" "index${rearIndexFormatted}-2-${filename}"
+    fi
+  done
+
+  (
+    echo "converting to PDF for $date..."
+    gm convert ${gm_opts[@]} ./*.pnm "/scans/${date}.pdf"
+    /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}.pdf"
+
+    echo "cleaning up for $date..."
+    cd /scans || exit
+    rm -rf "$date"
+
+    if [ -z "${OCR_SERVER}" ] || [ -z "${OCR_PORT}" ] || [ -z "${OCR_PATH}" ]; then
+      echo "OCR environment variables not set, skipping OCR."
+    else
+      echo "starting OCR for $date..."
+      (
+        curl -F "userfile=@/scans/$date.pdf" -H "Expect:" -o /scans/"$date"-ocr.pdf "${OCR_SERVER}":"${OCR_PORT}"/"${OCR_PATH}"
+        /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}-ocr.pdf"
+
+        /opt/brother/scanner/brscan-skey/script/sendtoftps.sh \
+          "${FTP_USER}" \
+          "${FTP_PASSWORD}" \
+          "${FTP_HOST}" \
+          "${FTP_PATH}" \
+          "${date}.pdf"
+      ) &
+    fi
+  ) &
 ) &

--- a/script/scantofile-0.2.4-1.sh
+++ b/script/scantofile-0.2.4-1.sh
@@ -3,84 +3,79 @@
 # $2 = friendly name
 
 {
-#override environment, as brscan is screwing it up:
-export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
+  #override environment, as brscan is screwing it up:
+  export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
 
-if [[ $RESOLUTION ]]; then
-  resolution=$RESOLUTION
-else
-  resolution=300
-fi
+  resolution="${RESOLUTION:-300}"
 
-if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
-    compression_flag="-compress JPEG -quality 80"
-else
-    compression_flag=""
-fi
-
-device=$1
-date=$(date +%Y-%m-%d-%H-%M-%S)
-
-mkdir "/scans/$date"
-cd "/scans/$date"
-filename_base=/scans/$date/$date"-front-page"
-output_file=$filename_base"%04d.pnm"
-echo "filename: "$output_file
-
-#sthg is wrong with device name, probably escaping, use default printer:
-#scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --device-name=$device --resolution=$resolution --batch=$output_file"
-scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --resolution=$resolution --batch=$output_file"
-
-if [ "`which usleep  2>/dev/null `" != '' ];then
-    usleep 100000
-else
-    sleep  0.1
-fi
-$($scan_cmd)
-if [ ! -s $filename_base"0001.pnm" ];then
-  if [ "`which usleep  2>/dev/null `" != '' ];then
-    usleep 1000000
-  else
-    sleep  1
+  gm_opts=(-page A4+0+0)
+  if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
+    gm_opts+=(-compress JPEG -quality 80)
   fi
-  $($scan_cmd)
-fi
 
-#only convert when no back pages are being scanned:
-(
-	if [ "`which usleep  2>/dev/null `" != '' ];then
-		usleep 120000000
-	else
-		sleep  120
-	fi
-	
-	(
-		echo "converting to PDF for $date..."
-		gm convert -page A4+0+0 $compression_flag $filename_base*.pnm /scans/$date.pdf
-		/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" $date.pdf
-	
-		echo "cleaning up for $date..."
-		cd /scans
-		rm -rf $date
-	
-		if [ -z "${OCR_SERVER}" ] || [ -z "${OCR_PORT}" ] || [ -z "${OCR_PATH}" ]; then
-			echo "OCR environment variables not set, skipping OCR."
-		else
-			echo "starting OCR for $date..."
-			(
-				curl -F "userfile=@/scans/$date.pdf" -H "Expect:" -o /scans/$date-ocr.pdf ${OCR_SERVER}:${OCR_PORT}/${OCR_PATH}
-				/opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" $date-ocr.pdf
-				/opt/brother/scanner/brscan-skey/script/sendtoftps.sh \
-				  "${FTP_USER}" \
-				  "${FTP_PASSWORD}" \
-				  "${FTP_HOST}" \
-				  "${FTP_PATH}" \
-				  "${date}.pdf"
-			) &
-		fi
-	) &
-) &
-echo $! > scan_pid
-echo "conversion process for $date is running in PID: "$(cat scan_pid)
+  # device=$1
+  date=$(date +%Y-%m-%d-%H-%M-%S)
 
-} >> /var/log/scanner.log 2>&1
+  mkdir -p "/tmp/$date"
+  cd "/tmp/$date" || exit
+  filename_base="/tmp/${date}/${date}-front-page"
+  output_file="${filename_base}%04d.pnm"
+  echo "filename: $output_file"
+
+  #sthg is wrong with device name, probably escaping, use default printer:
+  #scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --device-name=$device --resolution=$resolution --batch=$output_file"
+  scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --resolution=$resolution --batch=$output_file"
+
+  if [ "$(which usleep 2>/dev/null)" != '' ]; then
+    usleep 100000
+  else
+    sleep 0.1
+  fi
+  eval "$scan_cmd"
+  if [ ! -s "${filename_base}0001.pnm" ]; then
+    if [ "$(which usleep 2>/dev/null)" != '' ]; then
+      usleep 1000000
+    else
+      sleep 1
+    fi
+    eval "$scan_cmd"
+  fi
+
+  #only convert when no back pages are being scanned:
+  (
+    if [ "$(which usleep 2>/dev/null)" != '' ]; then
+      usleep 120000000
+    else
+      sleep 120
+    fi
+
+    (
+      echo "converting to PDF for $date..."
+      gm convert ${gm_opts[@]} "$filename_base"*.pnm "/scans/${date}.pdf"
+      /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}.pdf"
+
+      echo "cleaning up for $date..."
+      cd /scans || exit
+      rm -rf "$date"
+
+      if [ -z "${OCR_SERVER}" ] || [ -z "${OCR_PORT}" ] || [ -z "${OCR_PATH}" ]; then
+        echo "OCR environment variables not set, skipping OCR."
+      else
+        echo "starting OCR for $date..."
+        (
+          curl -F "userfile=@/scans/$date.pdf" -H "Expect:" -o /scans/"$date"-ocr.pdf "${OCR_SERVER}":"${OCR_PORT}"/"${OCR_PATH}"
+          /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}-ocr.pdf"
+          /opt/brother/scanner/brscan-skey/script/sendtoftps.sh \
+            "${FTP_USER}" \
+            "${FTP_PASSWORD}" \
+            "${FTP_HOST}" \
+            "${FTP_PATH}" \
+            "${date}.pdf"
+        ) &
+      fi
+    ) &
+  ) &
+  echo $! >scan_pid
+  echo "conversion process for $date is running in PID: $(cat scan_pid)"
+
+} >>/var/log/scanner.log 2>&1


### PR DESCRIPTION
This PR maintains the same functionality, but fixes some shellcheck linter warnings, making it easier for developers who run a linter to make future contributions.

It also saves working files in `/tmp`, so that programs that monitor the `/scans` directory (such as paperless-ngx) don't get notified about temporary files.