### PR TITLE
Fix temp directories left behind

### DIFF
--- a/files/runScanner.sh
+++ b/files/runScanner.sh
@@ -1,40 +1,40 @@
 #!/bin/bash
 echo "setting up user & logfile:"
 if [[ -z ${UID} ]]; then
-	UID=1000
+  UID=1000
 fi
 if [[ -z ${GID} ]]; then
-	GID=1000
+  GID=1000
 fi
-groupadd --gid $GID NAS
-adduser $USERNAME --uid $UID --gid $GID --disabled-password --force-badname --gecos ""
+groupadd --gid "$GID" NAS
+adduser "$USERNAME" --uid $UID --gid "$GID" --disabled-password --force-badname --gecos ""
 mkdir -p /scans
 chmod 777 /scans
 touch /var/log/scanner.log
-chown $USERNAME /var/log/scanner.log
-env > /opt/brother/scanner/env.txt
+chown "$USERNAME" /var/log/scanner.log
+env >/opt/brother/scanner/env.txt
 chmod -R 777 /opt/brother
 echo "-----"
 
 echo "setting up interface:"
-subnet=$(echo $IPADDRESS | sed 's/\([0-9]*\.[0-9]*\.\)[0-9]*\.[0-9]*/\1/')
-interface=$(ip addr show | grep -B10 $subnet | grep mtu | tail -1 | sed 's/[0-9]*: \(.*\): .*/\1/')
+subnet=$(echo "$IPADDRESS" | sed 's/\([0-9]*\.[0-9]*\.\)[0-9]*\.[0-9]*/\1/')
+interface=$(ip addr show | grep -B10 "$subnet" | grep mtu | tail -1 | sed 's/[0-9]*: \(.*\): .*/\1/')
 sed -i 's/^eth=.*//' /opt/brother/scanner/brscan-skey/brscan-skey.config
 # if found an interface for scanner subnet. Will use this to contact scanner.
 if [[ -z "$interface" ]]; then
-	# if scanner subnet (roughly) not found in interfaces, assuming network_mode="host" is not set and using Docker default interface. 
-	interface="eth0"
+  # if scanner subnet (roughly) not found in interfaces, assuming network_mode="host" is not set and using Docker default interface.
+  interface="eth0"
 fi
-echo "eth=$interface" >> /opt/brother/scanner/brscan-skey/brscan-skey.config
+echo "eth=$interface" >>/opt/brother/scanner/brscan-skey/brscan-skey.config
 echo "using interface: $interface"
 echo "-----"
 
 echo "setting up host IP:"
 sed -i 's/^ip_address=.*//' /opt/brother/scanner/brscan-skey/brscan-skey.config
 if [[ -z "$HOST_IPADDRESS" ]]; then
-	echo "no host IP configured, using default discovery"
+  echo "no host IP configured, using default discovery"
 else
-	echo "ip_address=$HOST_IPADDRESS" >> /opt/brother/scanner/brscan-skey/brscan-skey.config
+  echo "ip_address=$HOST_IPADDRESS" >>/opt/brother/scanner/brscan-skey/brscan-skey.config
 fi
 echo "-----"
 
@@ -43,54 +43,54 @@ cat /opt/brother/scanner/brscan-skey/brscan-skey.config
 echo "-----"
 
 echo "starting scanner drivers..."
-su - $USERNAME -c "/usr/bin/brsaneconfig4 -a name=$NAME model=$MODEL ip=$IPADDRESS"
-su - $USERNAME -c "/usr/bin/brscan-skey"
+su - "$USERNAME" -c "/usr/bin/brsaneconfig4 -a name=$NAME model=$MODEL ip=$IPADDRESS"
+su - "$USERNAME" -c "/usr/bin/brscan-skey"
 echo "-----"
 
 echo "setting up webserver:"
 if [ "$WEBSERVER" == "true" ]; then
-	echo "starting webserver for API & GUI..."
-	{
-		echo "<?php"
-		echo "\$UID=$UID;"
-		echo "\$MODEL=\"$MODEL\";"
-		if [[ -n "$RENAME_GUI_SCANTOFILE" ]]; then
-			echo "\$RENAME_GUI_SCANTOFILE=$RENAME_GUI_SCANTOFILE;"
-		fi
-		if [[ -n "$RENAME_GUI_SCANTOEMAIL" ]]; then
-			echo "\$RENAME_GUI_SCANTOEMAIL=$RENAME_GUI_SCANTOEMAIL;"
-		fi
-		if [[ -n "$RENAME_GUI_SCANTOIMAGE" ]]; then
-			echo "\$RENAME_GUI_SCANTOIMAGE=$RENAME_GUI_SCANTOIMAGE;"
-		fi
-		if [[ -n "$RENAME_GUI_SCANTOOCR" ]]; then
-			echo "\$RENAME_GUI_SCANTOOCR=$RENAME_GUI_SCANTOOCR;"
-		fi
-		if [[ -n "$DISABLE_GUI_SCANTOFILE" ]]; then
-			echo "\$DISABLE_GUI_SCANTOFILE=$DISABLE_GUI_SCANTOFILE;"
-		fi
-		if [[ -n "$DISABLE_GUI_SCANTOEMAIL" ]]; then
-			echo "\$DISABLE_GUI_SCANTOEMAIL=$DISABLE_GUI_SCANTOEMAIL;"
-		fi
-		if [[ -n "$DISABLE_GUI_SCANTOIMAGE" ]]; then
-			echo "\$DISABLE_GUI_SCANTOIMAGE=$DISABLE_GUI_SCANTOIMAGE;"
-		fi
-		if [[ -n "$DISABLE_GUI_SCANTOOCR" ]]; then
-			echo "\$DISABLE_GUI_SCANTOOCR=$DISABLE_GUI_SCANTOOCR;"
-		fi
-		echo "?>"
-		
-	} > /var/www/html/config.php
-	chown www-data /var/www/html/config.php
-	if [[ -z ${PORT} ]]; then
-		PORT=80
-	fi
-	echo "running on port $PORT"
-	sed -i "s/server.port\W*= 80/server.port = $PORT/" /etc/lighttpd/lighttpd.conf
-	/usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
-	echo "webserver started"
+  echo "starting webserver for API & GUI..."
+  {
+    echo "<?php"
+    echo "\$UID=$UID;"
+    echo "\$MODEL=\"$MODEL\";"
+    if [[ -n "$RENAME_GUI_SCANTOFILE" ]]; then
+      echo "\$RENAME_GUI_SCANTOFILE=$RENAME_GUI_SCANTOFILE;"
+    fi
+    if [[ -n "$RENAME_GUI_SCANTOEMAIL" ]]; then
+      echo "\$RENAME_GUI_SCANTOEMAIL=$RENAME_GUI_SCANTOEMAIL;"
+    fi
+    if [[ -n "$RENAME_GUI_SCANTOIMAGE" ]]; then
+      echo "\$RENAME_GUI_SCANTOIMAGE=$RENAME_GUI_SCANTOIMAGE;"
+    fi
+    if [[ -n "$RENAME_GUI_SCANTOOCR" ]]; then
+      echo "\$RENAME_GUI_SCANTOOCR=$RENAME_GUI_SCANTOOCR;"
+    fi
+    if [[ -n "$DISABLE_GUI_SCANTOFILE" ]]; then
+      echo "\$DISABLE_GUI_SCANTOFILE=$DISABLE_GUI_SCANTOFILE;"
+    fi
+    if [[ -n "$DISABLE_GUI_SCANTOEMAIL" ]]; then
+      echo "\$DISABLE_GUI_SCANTOEMAIL=$DISABLE_GUI_SCANTOEMAIL;"
+    fi
+    if [[ -n "$DISABLE_GUI_SCANTOIMAGE" ]]; then
+      echo "\$DISABLE_GUI_SCANTOIMAGE=$DISABLE_GUI_SCANTOIMAGE;"
+    fi
+    if [[ -n "$DISABLE_GUI_SCANTOOCR" ]]; then
+      echo "\$DISABLE_GUI_SCANTOOCR=$DISABLE_GUI_SCANTOOCR;"
+    fi
+    echo "?>"
+
+  } >/var/www/html/config.php
+  chown www-data /var/www/html/config.php
+  if [[ -z ${PORT} ]]; then
+    PORT=80
+  fi
+  echo "running on port $PORT"
+  sed -i "s/server.port\W*= 80/server.port = $PORT/" /etc/lighttpd/lighttpd.conf
+  /usr/sbin/lighttpd -f /etc/lighttpd/lighttpd.conf
+  echo "webserver started"
 else
-	echo "webserver not configured"
+  echo "webserver not configured"
 fi
 echo "-----"
 
@@ -98,8 +98,7 @@ echo "capabilities:"
 scanimage -A
 
 echo "startup successful"
-while true;
-do
+while true; do
   tail -f /var/log/scanner.log
 done
 exit 0

--- a/script/scanRear.sh
+++ b/script/scanRear.sh
@@ -12,36 +12,44 @@ if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
   gm_opts+=(-compress JPEG -quality 80)
 fi
 
-# device=$1
+device="$1"
+script_dir="/opt/brother/scanner/brscan-skey/script"
+
 mkdir -p /tmp
 cd /tmp || exit
 date=$(ls -rd */ | grep "$(date +"%Y-%m-%d")" | head -1)
 date=${date%/}
-filename_base="/tmp/$date/${date}-back-page"
-output_file="${filename_base}%04d.pnm"
+tmp_dir="/tmp/${date}"
+filename_base="${tmp_dir}/${date}-back-page"
+tmp_output_file="${filename_base}%04d.pnm"
+tmp_output_pdf_file="${tmp_dir}/${date}.pdf"
+output_pdf_file="/scans/${date}.pdf"
 
-cd "/tmp/${date}" || exit
+cd "$tmp_dir" || exit
 
 pkill -P "$(cat scan_pid)"
 rm scan_pid
 
-#sthg is wrong with device name, probably escaping, use default printer:
-#scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --device-name=$device --resolution=$resolution --batch=$output_file"
-scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --resolution=$resolution --batch=$output_file"
+function scan_cmd() {
+  # `brother4:net1;dev0` device name gets passed to scanimage, which it refuses as an invalid device name for some reason.
+  # Let's use the default scanner for now
+  # scanimage -l 0 -t 0 -x 215 -y 297 --device-name="$1" --resolution="$2" --batch="$3"
+  scanimage -l 0 -t 0 -x 215 -y 297 --format=pnm --resolution="$2" --batch="$3"
+}
 
 if [ "$(which usleep 2>/dev/null)" != '' ]; then
   usleep 100000
 else
   sleep 0.1
 fi
-eval "$scan_cmd"
+scan_cmd "$device" "$resolution" "$tmp_output_file"
 if [ ! -s "${filename_base}0001.pnm" ]; then
   if [ "$(which usleep 2>/dev/null)" != '' ]; then
     usleep 1000000
   else
     sleep 1
   fi
-  eval "$scan_cmd"
+  scan_cmd "$device" "$resolution" "$tmp_output_file"
 fi
 
 (
@@ -70,28 +78,28 @@ fi
 
   (
     echo "converting to PDF for $date..."
-    gm convert ${gm_opts[@]} ./*.pnm "/scans/${date}.pdf"
-    /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}.pdf"
-    /opt/brother/scanner/brscan-skey/script/trigger_telegram.sh "${date}.pdf (rear) scanned"
+    gm convert ${gm_opts[@]} ./*.pnm "$output_pdf_file"
+    ${script_dir}/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${output_pdf_file}"
+    ${script_dir}/trigger_telegram.sh "${date}.pdf (rear) scanned"
 
     echo "cleaning up for $date..."
     cd /scans || exit
-    rm -rf "$date"
+    rm -rf "$tmp_dir"
 
     if [ -z "${OCR_SERVER}" ] || [ -z "${OCR_PORT}" ] || [ -z "${OCR_PATH}" ]; then
       echo "OCR environment variables not set, skipping OCR."
     else
       echo "starting OCR for $date..."
       (
-        curl -F "userfile=@/scans/$date.pdf" -H "Expect:" -o /scans/"$date"-ocr.pdf "${OCR_SERVER}":"${OCR_PORT}"/"${OCR_PATH}"
-        /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}-ocr.pdf"
-        /opt/brother/scanner/brscan-skey/script/trigger_telegram.sh "${date}-ocr.pdf (rear) OCR finished"
-        /opt/brother/scanner/brscan-skey/script/sendtoftps.sh \
+        curl -F "userfile=@${output_pdf_file}" -H "Expect:" -o "/scans/${date}-ocr.pdf" "${OCR_SERVER}":"${OCR_PORT}"/"${OCR_PATH}"
+        ${script_dir}/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}-ocr.pdf"
+        ${script_dir}/trigger_telegram.sh "${date}-ocr.pdf (rear) OCR finished"
+        ${script_dir}/sendtoftps.sh \
           "${FTP_USER}" \
           "${FTP_PASSWORD}" \
           "${FTP_HOST}" \
           "${FTP_PATH}" \
-          "${date}.pdf"
+          "${output_pdf_file}"
       ) &
     fi
   ) &

--- a/script/scantoemail-0.2.4-1.sh
+++ b/script/scantoemail-0.2.4-1.sh
@@ -3,11 +3,14 @@
 # $2 = friendly name
 
 {
-echo "scantoemail.sh triggered"
-#override environment, as brscan is screwing it up:
-export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
+  echo "scantoemail.sh triggered"
+  #override environment, as brscan is screwing it up:
+  export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
 
-SCRIPTPATH="$( cd "$(dirname "$0")" ; pwd -P )"
-/bin/bash $SCRIPTPATH/scanRear.sh $@
+  SCRIPTPATH="$(
+    cd "$(dirname "$0")" || exit
+    pwd -P
+  )"
+  /bin/bash "$SCRIPTPATH"/scanRear.sh $@
 
-} >> /var/log/scanner.log 2>&1
+} >>/var/log/scanner.log 2>&1

--- a/script/scantofile-0.2.4-1.sh
+++ b/script/scantofile-0.2.4-1.sh
@@ -15,6 +15,7 @@
 
   # device=$1
   date=$(date +%Y-%m-%d-%H-%M-%S)
+  tmp_dir="/tmp/$date"
 
   mkdir -p "/tmp/$date"
   cd "/tmp/$date" || exit
@@ -57,7 +58,7 @@
 
       echo "cleaning up for $date..."
       cd /scans || exit
-      rm -rf "$date"
+      rm -rf "$tmp_dir"
 
       if [ -z "${OCR_SERVER}" ] || [ -z "${OCR_PORT}" ] || [ -z "${OCR_PATH}" ]; then
         echo "OCR environment variables not set, skipping OCR."

--- a/script/scantofile-0.2.4-1.sh
+++ b/script/scantofile-0.2.4-1.sh
@@ -13,33 +13,38 @@
     gm_opts+=(-compress JPEG -quality 80)
   fi
 
-  # device=$1
+  device="$1"
   date=$(date +%Y-%m-%d-%H-%M-%S)
+  script_dir="/opt/brother/scanner/brscan-skey/script"
   tmp_dir="/tmp/$date"
+  filename_base="${tmp_dir}/${date}-front-page"
+  tmp_output_file="${filename_base}%04d.pnm"
+  output_pdf_file="/scans/${date}.pdf"
 
-  mkdir -p "/tmp/$date"
-  cd "/tmp/$date" || exit
-  filename_base="/tmp/${date}/${date}-front-page"
-  output_file="${filename_base}%04d.pnm"
-  echo "filename: $output_file"
+  mkdir -p "$tmp_dir"
+  cd "$tmp_dir" || exit
+  echo "filename: $tmp_output_file"
 
-  #sthg is wrong with device name, probably escaping, use default printer:
-  #scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --device-name=$device --resolution=$resolution --batch=$output_file"
-  scan_cmd="scanimage -l 0 -t 0 -x 215 -y 297 --resolution=$resolution --batch=$output_file"
+  function scan_cmd() {
+    # `brother4:net1;dev0` device name gets passed to scanimage, which it refuses as an invalid device name for some reason.
+    # Let's use the default scanner for now
+    # scanimage -l 0 -t 0 -x 215 -y 297 --device-name="$1" --resolution="$2" --batch="$3"
+    scanimage -l 0 -t 0 -x 215 -y 297 --format=pnm --resolution="$2" --batch="$3"
+  }
 
   if [ "$(which usleep 2>/dev/null)" != '' ]; then
     usleep 100000
   else
     sleep 0.1
   fi
-  eval "$scan_cmd"
+  scan_cmd "$device" "$resolution" "$tmp_output_file"
   if [ ! -s "${filename_base}0001.pnm" ]; then
     if [ "$(which usleep 2>/dev/null)" != '' ]; then
       usleep 1000000
     else
       sleep 1
     fi
-    eval "$scan_cmd"
+    scan_cmd "$device" "$resolution" "$tmp_output_file"
   fi
 
   #only convert when no back pages are being scanned:
@@ -52,9 +57,9 @@
 
     (
       echo "converting to PDF for $date..."
-      gm convert ${gm_opts[@]} "$filename_base"*.pnm "/scans/${date}.pdf"
-      /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}.pdf"
-      /opt/brother/scanner/brscan-skey/script/trigger_telegram.sh "${date}.pdf (front) scanned"
+      gm convert ${gm_opts[@]} "$filename_base"*.pnm "$output_pdf_file"
+      ${script_dir}/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${output_pdf_file}"
+      ${script_dir}/trigger_telegram.sh "${date}.pdf (front) scanned"
 
       echo "cleaning up for $date..."
       cd /scans || exit
@@ -65,15 +70,15 @@
       else
         echo "starting OCR for $date..."
         (
-          curl -F "userfile=@/scans/$date.pdf" -H "Expect:" -o /scans/"$date"-ocr.pdf "${OCR_SERVER}":"${OCR_PORT}"/"${OCR_PATH}"
-          /opt/brother/scanner/brscan-skey/script/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}-ocr.pdf"
-          /opt/brother/scanner/brscan-skey/script/trigger_telegram.sh "${date}-ocr.pdf (front) OCR finished"
-          /opt/brother/scanner/brscan-skey/script/sendtoftps.sh \
+          curl -F "userfile=@${output_pdf_file}" -H "Expect:" -o "/scans/${date}-ocr.pdf" "${OCR_SERVER}":"${OCR_PORT}"/"${OCR_PATH}"
+          ${script_dir}/trigger_inotify.sh "${SSH_USER}" "${SSH_PASSWORD}" "${SSH_HOST}" "${SSH_PATH}" "${date}-ocr.pdf"
+          ${script_dir}/trigger_telegram.sh "${date}-ocr.pdf (front) OCR finished"
+          ${script_dir}/sendtoftps.sh \
             "${FTP_USER}" \
             "${FTP_PASSWORD}" \
             "${FTP_HOST}" \
             "${FTP_PATH}" \
-            "${date}.pdf"
+            "${output_pdf_file}"
         ) &
       fi
     ) &

--- a/script/scantoimage-0.2.4-1.sh
+++ b/script/scantoimage-0.2.4-1.sh
@@ -4,9 +4,9 @@
 
 {
 
-echo "ERROR!"
-echo "This function is not implemented."
-echo "You may implement your own script and mount under $0."
-echo "Check out scripts in same folder or https://github.com/PhilippMundhenk/BrotherScannerDocker for examples."
-  
-} >> /var/log/scanner.log 2>&1
+  echo "ERROR!"
+  echo "This function is not implemented."
+  echo "You may implement your own script and mount under $0."
+  echo "Check out scripts in same folder or https://github.com/PhilippMundhenk/BrotherScannerDocker for examples."
+
+} >>/var/log/scanner.log 2>&1

--- a/script/scantoocr-0.2.4-1.sh
+++ b/script/scantoocr-0.2.4-1.sh
@@ -4,9 +4,9 @@
 
 {
 
-echo "ERROR!"
-echo "This function is not implemented."
-echo "You may implement your own script and mount under $0."
-echo "Check out scripts in same folder or https://github.com/PhilippMundhenk/BrotherScannerDocker for examples."
+  echo "ERROR!"
+  echo "This function is not implemented."
+  echo "You may implement your own script and mount under $0."
+  echo "Check out scripts in same folder or https://github.com/PhilippMundhenk/BrotherScannerDocker for examples."
 
-} >> /var/log/scanner.log 2>&1
+} >>/var/log/scanner.log 2>&1

--- a/script/trigger_inotify.sh
+++ b/script/trigger_inotify.sh
@@ -7,11 +7,10 @@ file=$5
 if [ -z "${user}" ] || [ -z "${password}" ] || [ -z "${address}" ] || [ -z "${filepath}" ]; then
   echo "SSH environment variables not set, skipping inotify trigger."
 else
-  if sshpass -p "$password" ssh -o StrictHostKeyChecking=no $user@$address "sed \"\" -i $filepath/$file"; then
+  if sshpass -p "$password" ssh -o StrictHostKeyChecking=no "$user"@"$address" "sed \"\" -i $filepath/$file"; then
     echo "trigger inotify successful"
   else
     echo "trigger inotify failed"
     exit 1
   fi
 fi
-

--- a/script/trigger_telegram.sh
+++ b/script/trigger_telegram.sh
@@ -17,4 +17,4 @@ MESSAGE="Scanner: $1"
 ENCODED_MESSAGE=$(echo "$MESSAGE" | jq -sRr @uri)
 
 # Send the message using wget
-wget -qO- --post-data="chat_id=$CHAT_ID&text=$ENCODED_MESSAGE" "https://api.telegram.org/$TOKEN/sendMessage" > /dev/null
+wget -qO- --post-data="chat_id=$CHAT_ID&text=$ENCODED_MESSAGE" "https://api.telegram.org/$TOKEN/sendMessage" >/dev/null


### PR DESCRIPTION
My last change to `scantofile-0.2.4-1.sh` unfortunately introduced a bug where the `rm -rf` command was not being applied to a correctly named directory. This PR fixes it and further cleans up the scripts to make more use of variables to avoid repetition.