### PR TITLE
Exit script if scan cancelled

### DIFF
--- a/script/scanRear.sh
+++ b/script/scanRear.sh
@@ -15,8 +15,10 @@ fi
 device="$1"
 script_dir="/opt/brother/scanner/brscan-skey/script"
 
+set -e # Exit on error
+
 mkdir -p /tmp
-cd /tmp || exit
+cd /tmp
 date=$(ls -rd */ | grep "$(date +"%Y-%m-%d")" | head -1)
 date=${date%/}
 tmp_dir="/tmp/${date}"
@@ -25,7 +27,7 @@ tmp_output_file="${filename_base}%04d.pnm"
 tmp_output_pdf_file="${tmp_dir}/${date}.pdf"
 output_pdf_file="/scans/${date}.pdf"
 
-cd "$tmp_dir" || exit
+cd "$tmp_dir"
 
 kill -9 "$(cat scan_pid)"
 rm scan_pid

--- a/script/scantofile-0.2.4-1.sh
+++ b/script/scantofile-0.2.4-1.sh
@@ -21,8 +21,12 @@
   tmp_output_file="${filename_base}%04d.pnm"
   output_pdf_file="/scans/${date}.pdf"
 
+  set -e # Exit on error
+
   mkdir -p "$tmp_dir"
-  cd "$tmp_dir" || exit
+  cd "$tmp_dir"
+  filename_base="/tmp/${date}/${date}-front-page"
+  output_file="${filename_base}%04d.pnm"
   echo "filename: $tmp_output_file"
 
   function scan_cmd() {

--- a/script/trigger_telegram.sh
+++ b/script/trigger_telegram.sh
@@ -3,18 +3,17 @@
 # Check if TELEGRAM_TOKEN and TELEGRAM_CHATID are both set
 if [ -z "${TELEGRAM_TOKEN}" ] || [ -z "${TELEGRAM_CHATID}" ]; then
   echo "TELEGRAM_TOKEN or TELEGRAM_CHATID is not set"
-  exit 1
+else
+  # Use the environment variables TELEGRAM_TOKEN and TELEGRAM_CHATID
+  TOKEN="$TELEGRAM_TOKEN"
+  CHAT_ID="$TELEGRAM_CHATID"
+
+  # The message is passed as a parameter
+  MESSAGE="Scanner: $1"
+
+  # URL encode the message to handle spaces and special characters
+  ENCODED_MESSAGE=$(echo "$MESSAGE" | jq -sRr @uri)
+
+  # Send the message using wget
+  wget -qO- --post-data="chat_id=$CHAT_ID&text=$ENCODED_MESSAGE" "https://api.telegram.org/$TOKEN/sendMessage" >/dev/null
 fi
-
-# Use the environment variables TELEGRAM_TOKEN and TELEGRAM_CHATID
-TOKEN="$TELEGRAM_TOKEN"
-CHAT_ID="$TELEGRAM_CHATID"
-
-# The message is passed as a parameter
-MESSAGE="Scanner: $1"
-
-# URL encode the message to handle spaces and special characters
-ENCODED_MESSAGE=$(echo "$MESSAGE" | jq -sRr @uri)
-
-# Send the message using wget
-wget -qO- --post-data="chat_id=$CHAT_ID&text=$ENCODED_MESSAGE" "https://api.telegram.org/$TOKEN/sendMessage" >/dev/null


### PR DESCRIPTION
Currently, the script continues to execute if the user cancels the scan on the scanner control panel. We should exit in that situation.