### PR TITLE
Cleanup Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,53 +1,51 @@
-#FROM ubuntu:16.04
-FROM ubuntu:22.04
+FROM python:slim-bullseye
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get -y install tzdata && apt-get -y clean
-
-RUN apt-get update && apt-get install -y --no-install-recommends apt-utils && apt-get -y clean
-
-RUN apt-get -y update && apt-get -y upgrade && apt-get -y clean
-RUN apt-get -y install \
-  sane \
-  sane-utils \
-  ghostscript \
-  netpbm \
-  x11-common \
-  wget \
-  graphicsmagick \
+RUN <<EOF
+apt-get update && \
+apt-get -y --no-install-recommends install \
+  bc \
   curl \
-  ssh \
-  sshpass \
-  lighttpd \
-  php-cgi \
-  php-curl \
-  sudo \
+  ghostscript \
+  graphicsmagick \
   iproute2 \
   jq \
-  bc \
+  lighttpd \
+  netbase \
+  netpbm \
   pdftk \
+  php-cgi \
+  php-curl \
   poppler-utils \
-  && apt-get -y clean
+  python3 \
+  sane \
+  sane-utils \
+  ssh \
+  sshpass \
+  sudo \
+  tzdata \
+  wget \
+  x11-common && \
+apt-get -y clean && \
+rm -rf /var/lib/apt/lists/* && \
+wget https://download.brother.com/welcome/dlf105200/brscan4-0.4.11-1.amd64.deb --progress=dot:giga -O /tmp/brscan4.deb && \
+wget https://download.brother.com/welcome/dlf006652/brscan-skey-0.3.2-0.amd64.deb --progress=dot:giga -O /tmp/brscan-skey.deb && \
+dpkg -i --force-all /tmp/brscan4.deb && \
+dpkg -i --force-all /tmp/brscan-skey.deb && \
+rm -f /tmp/brscan4.deb /tmp/brscan-skey.deb
+EOF
 
-RUN cd /tmp && \
-  wget https://download.brother.com/welcome/dlf105200/brscan4-0.4.11-1.amd64.deb && \
-  dpkg -i /tmp/brscan4-0.4.11-1.amd64.deb && \
-  rm /tmp/brscan4-0.4.11-1.amd64.deb
-
-RUN cd /tmp && \
-  wget https://download.brother.com/welcome/dlf006652/brscan-skey-0.3.1-2.amd64.deb && \
-  dpkg -i /tmp/brscan-skey-0.3.1-2.amd64.deb && \
-  rm /tmp/brscan-skey-0.3.1-2.amd64.deb
-
-ADD files/runScanner.sh /opt/brother/runScanner.sh
+COPY files/runScanner.sh /opt/brother/runScanner.sh
 COPY script /opt/brother/scanner/brscan-skey/script
 
-RUN cp /etc/lighttpd/conf-available/05-auth.conf /etc/lighttpd/conf-enabled/
-RUN cp /etc/lighttpd/conf-available/15-fastcgi-php.conf /etc/lighttpd/conf-enabled/
-RUN cp /etc/lighttpd/conf-available/10-fastcgi.conf /etc/lighttpd/conf-enabled/
-RUN mkdir -p /var/run/lighttpd
-RUN touch /var/run/lighttpd/php-fastcgi.socket
-RUN chown -R www-data /var/run/lighttpd
-RUN echo 'www-data ALL=(NAS) NOPASSWD:ALL' >> /etc/sudoers
+RUN <<EOF
+cp /etc/lighttpd/conf-available/05-auth.conf /etc/lighttpd/conf-enabled/ && \
+cp /etc/lighttpd/conf-available/15-fastcgi-php.conf /etc/lighttpd/conf-enabled/ && \
+cp /etc/lighttpd/conf-available/10-fastcgi.conf /etc/lighttpd/conf-enabled/ && \
+mkdir -p /var/run/lighttpd && \
+touch /var/run/lighttpd/php-fastcgi.socket && \
+chown -R www-data /var/run/lighttpd && \
+echo 'www-data ALL=(NAS) NOPASSWD:ALL' >> /etc/sudoers
+EOF
 
 ENV NAME="Scanner"
 ENV MODEL="MFC-L2700DW"
@@ -55,27 +53,23 @@ ENV IPADDRESS="192.168.1.123"
 ENV USERNAME="NAS"
 ENV REMOVE_BLANK_THRESHOLD="0.3"
 
-#only set these variables in the compose file, if inotify needs to be triggered (e.g., for Synology Drive):
+# Only set these variables in the compose file, if inotify needs to be triggered (e.g., for Synology Drive):
 ENV SSH_USER=""
 ENV SSH_PASSWORD=""
 ENV SSH_HOST=""
 ENV SSH_PATH=""
 
-#only set these variables in the compose file, if you need FTP upload:
+# Only set these variables in the compose file, if you need FTP upload:
 ENV FTP_USER=""
 ENV FTP_PASSWORD=""
 ENV FTP_HOST=""
 
-#only set these variables in the compose file, if you need Telegram notifications:
+# Only set these variables in the compose file, if you need Telegram notifications:
 ENV TELEGRAM_TOKEN=""
 ENV TELEGRAM_CHATID=""
 
 # Make sure this ends in a slash.
 ENV FTP_PATH="/scans/"
-
-EXPOSE 54925
-EXPOSE 54921
-EXPOSE 80
 
 #ADD files/gui/index.php /var/www/html
 #ADD files/gui/main.css /var/www/html
@@ -85,9 +79,8 @@ EXPOSE 80
 #ADD files/api/download.php /var/www/html
 COPY html /var/www/html
 RUN chown -R www-data /var/www/
+
 #directory for scans:
 VOLUME /scans
 
-CMD /opt/brother/runScanner.sh
-
-
+CMD ["bash", "-c", "/opt/brother/runScanner.sh"]


### PR DESCRIPTION
This change tries to minimize the size of the resulting image (by reducing layers, and not installing optional tools), and also allow specifying a `brscan-skey.config` (which will later allow us to use Python scripts directly).

Comparison between images (new image on the bottom):

<img width="1765" alt="image" src="https://github.com/user-attachments/assets/f93b6149-004a-4e7e-a505-fbfe1d427791">

It went from 1.1 GB to 764 MB (30% reduction with no change in functionality), and efficiency from 97 % to 99 %.

I've also linted the Dockerfile at https://www.fromlatest.io/ and implemented some of the suggestions.