### PR TITLE
Add mode option to environment variables

### DIFF
--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -18,6 +18,7 @@ services:
             - GID=1000 # note: network mount needs to have correct permissions!
             - TZ=Europe/Berlin
             - HOST_IPADDRESS=192.168.188.117
+            # -MODE=Gray
             - WEBSERVER=true
             - RENAME_GUI_SCANTOFILE="Scan front pages"
             - RENAME_GUI_SCANTOEMAIL="Scan rear pages"

--- a/script/scanRear.sh
+++ b/script/scanRear.sh
@@ -6,6 +6,11 @@
 export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
 
 resolution="${RESOLUTION:-300}"
+if [[ $MODE ]]; then
+  mode="--mode $MODE"
+else
+  mode=""
+fi
 
 gm_opts=(-page A4+0+0)
 if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
@@ -37,7 +42,7 @@ function scan_cmd() {
   # `brother4:net1;dev0` device name gets passed to scanimage, which it refuses as an invalid device name for some reason.
   # Let's use the default scanner for now
   # scanimage -l 0 -t 0 -x 215 -y 297 --device-name="$1" --resolution="$2" --batch="$3"
-  scanimage -l 0 -t 0 -x 215 -y 297 --format=pnm --resolution="$2" --batch="$3"
+  scanimage -l 0 -t 0 -x 215 -y 297 --format=pnm --resolution="$2" --batch="$3" "$mode"
 }
 
 if [ "$(which usleep 2>/dev/null)" != '' ]; then
@@ -45,14 +50,14 @@ if [ "$(which usleep 2>/dev/null)" != '' ]; then
 else
   sleep 0.1
 fi
-scan_cmd "$device" "$resolution" "$tmp_output_file"
+scan_cmd "$device" "$resolution" "$tmp_output_file" "$mode"
 if [ ! -s "${filename_base}0001.pnm" ]; then
   if [ "$(which usleep 2>/dev/null)" != '' ]; then
     usleep 1000000
   else
     sleep 1
   fi
-  scan_cmd "$device" "$resolution" "$tmp_output_file"
+  scan_cmd "$device" "$resolution" "$tmp_output_file" "$mode"
 fi
 
 (

--- a/script/scantofile-0.2.4-1.sh
+++ b/script/scantofile-0.2.4-1.sh
@@ -7,6 +7,11 @@
   export $(grep -v '^#' /opt/brother/scanner/env.txt | xargs)
 
   resolution="${RESOLUTION:-300}"
+  if [[ $MODE ]]; then
+    mode="--mode $MODE"
+  else
+    mode=""
+  fi
 
   gm_opts=(-page A4+0+0)
   if [ "$USE_JPEG_COMPRESSION" = "true" ]; then
@@ -33,7 +38,7 @@
     # `brother4:net1;dev0` device name gets passed to scanimage, which it refuses as an invalid device name for some reason.
     # Let's use the default scanner for now
     # scanimage -l 0 -t 0 -x 215 -y 297 --device-name="$1" --resolution="$2" --batch="$3"
-    scanimage -l 0 -t 0 -x 215 -y 297 --format=pnm --resolution="$2" --batch="$3"
+    scanimage -l 0 -t 0 -x 215 -y 297 --format=pnm --resolution="$2" --batch="$3" "$mode"
   }
 
   if [ "$(which usleep 2>/dev/null)" != '' ]; then
@@ -48,7 +53,7 @@
     else
       sleep 1
     fi
-    scan_cmd "$device" "$resolution" "$tmp_output_file"
+    scan_cmd "$device" "$resolution" "$tmp_output_file" "$mode"
   fi
 
   #only convert when no back pages are being scanned:


### PR DESCRIPTION
Default scan mode is colour leading to large files. It might be desirable to instead scan in greyscale drastically reducing the file size. This is especially the case for use with for example paperless-ngx.

I have implemented this crude addition in a previous version on top of `d1ee52f2bc7612ea867cce13f5be46a3a9447b52`. Unfortunately I am currently not able to test this addition in the new version. Furthermore, I don't know if the handling is correct for options containing a white space (see `scanimage -h`):

> -mode Black & White|Gray[Error Diffusion]|True Gray|24bit Color[Fast] [24bit Color[Fast]]

Maybe see this more as a feature request.